### PR TITLE
Upgrading  php_codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://withknown.com",
     "require": {
         "php": ">=7.0",
-        "squizlabs/php_codesniffer": "3.4.1"
+        "squizlabs/php_codesniffer": "3.5.8"
     },
     "license": "GPL-2.0-only",
     "keywords" : ["i18n", "Known"],


### PR DESCRIPTION
The existing version doesn't work in PHP 8.